### PR TITLE
Pull request for CMS Adapter & Contenthub integration

### DIFF
--- a/sling-stanbol-commons/src/main/java/org/apache/sling/stanbol/commons/Constants.java
+++ b/sling-stanbol-commons/src/main/java/org/apache/sling/stanbol/commons/Constants.java
@@ -20,7 +20,7 @@ import org.apache.clerezza.rdf.core.UriRef;
 
 public class Constants {
 	
-	public static final UriRef enhancementMGraphUri = new UriRef("urn:x-localinstance:/enhancement.graph");
-	//public static final UriRef enhancementMGraphUri = new UriRef("org.apache.stanbol.enhancer.standalone.store.enhancemenets");
+//	public static final UriRef enhancementMGraphUri = new UriRef("urn:x-localinstance:/enhancement.graph");
+	public static final UriRef enhancementMGraphUri = new UriRef("org.apache.stanbol.enhancer.standalone.store.enhancements");
 	
 }

--- a/sling-stanbol-jcr-observer/pom.xml
+++ b/sling-stanbol-jcr-observer/pom.xml
@@ -92,6 +92,16 @@
 			<artifactId>org.apache.stanbol.enhancer.servicesapi</artifactId>
 			<version>0.9.0-incubating-SNAPSHOT</version>
 		</dependency>
+        <dependency>
+          <groupId>org.apache.stanbol</groupId>
+          <artifactId>org.apache.stanbol.cmsadapter.servicesapi</artifactId>
+          <version>0.9.0-incubating-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.stanbol</groupId>
+          <artifactId>org.apache.stanbol.cmsadapter.core</artifactId>
+          <version>0.9.0-incubating-SNAPSHOT</version>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.clerezza</groupId>
 			<artifactId>rdf.core</artifactId>

--- a/sling-stanbol-launcher/.gitignore
+++ b/sling-stanbol-launcher/.gitignore
@@ -1,1 +1,5 @@
 /sling/
+derby.log
+factstore/
+jackrabbit/
+target/

--- a/sling-stanbol-launcher/pom.xml
+++ b/sling-stanbol-launcher/pom.xml
@@ -39,6 +39,24 @@
     </description>
 	<build>
 		<plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <configuration>
+            <filesets>
+              <fileset>
+                <directory>.</directory>
+                <includes>
+                  <include>sling/**</include>
+                  <include>jackrabbit/**</include>
+                  <include>target/**</include>
+                  <include>factstore/**</include>
+                  <include>*.log</include>
+                </includes>
+              </fileset>
+            </filesets>
+          </configuration>
+        </plugin>    
 			<plugin>
 				<groupId>org.apache.sling</groupId>
 				<artifactId>maven-launchpad-plugin</artifactId>

--- a/sling-stanbol-launcher/src/main/bundles/list.xml
+++ b/sling-stanbol-launcher/src/main/bundles/list.xml
@@ -315,7 +315,7 @@
 			<version>0.9.9-SNAPSHOT</version>
 		</bundle>
 	</startLevel>
-	<startLevel level="21">
+	<startLevel level="24">
 		<bundle>
 			<groupId>org.apache.sling</groupId>
 			<artifactId>org.apache.sling.extensions.jaxrs</artifactId>


### PR DESCRIPTION
-Added CMS Adapter and Contenthub integration such that the documents catched in JCR listener are submitted to Contenthub with the help of CMS Adapter.
-As enhancement graph URI the one belonging to Contenthub is used
-Added detailed clean statements for maven-clean-plugin
-Changed the start level of sling-stanbol bundles such that they would come after CMS Adapter bundles
